### PR TITLE
Adding basic support for popstate event

### DIFF
--- a/ext/route_browser.js
+++ b/ext/route_browser.js
@@ -2,7 +2,7 @@ if (typeof window !== "undefined") {
   // redirect to route, push state
   E.route.on("visit", function(to) {
     try {
-      history.pushState(null, null, to);
+      history.pushState({ edenjs: true }, '', to);
     } catch (err) {
       window.location = to[0] === "#" ? to : "#" + to;
     }
@@ -20,4 +20,11 @@ if (typeof window !== "undefined") {
       if (document.readyState === "complete") E.route.load();
     });
   }
+
+  // Popstate event
+  window.addEventListener('popstate', function (e) {
+    if (e.state !== null && e.state['edenjs']) {
+      E.route.load();
+    }
+  });
 };


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/Events/popstate
It allows the navigation with the browser "back button".

This is a simple implementation and it works with major browsers + IE10+.

Also, it's good to send the your ID "state". If you have multiple libraries changing the state of the URL, you need to know if you are responsible for that route. That's why I am passing {edenjs: true} as a state.

Oh, and the second param I am passing a blank string because it is recommended by MDN:

"title — Firefox currently ignores this parameter, although it may use it in the future. Passing the empty string here should be safe against future changes to the method. Alternatively, you could pass a short title for the state to which you're moving."
