### PR TITLE
Fix template single quotes issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,9 +94,10 @@ S.template = (function() {
     return new Function("obj",
       "var p=[];" +
       "with(obj){p.push('" + str
+        .replace(/'/g, "\\'")
         .replace(/[\r\t\n]/g, " ")
         .split(prefix).join("\t")
-        .replace(new RegExp("((^|" + sufix +")[^\t]*)'", "g"), "$1\r")
+        .replace(new RegExp("((^|" + sufix +")[^\t]*)[^\\']'", "g"), "$1\r")
         .replace(new RegExp("\t=(.*?)" + sufix, "g"), "',$1,'")
         .split("\t").join("');")
         .split(sufix).join("p.push('")

--- a/lib/template.js
+++ b/lib/template.js
@@ -14,9 +14,10 @@ S.template = (function() {
     return new Function("obj",
       "var p=[];" +
       "with(obj){p.push('" + str
+        .replace(/'/g, "\\'")
         .replace(/[\r\t\n]/g, " ")
         .split(prefix).join("\t")
-        .replace(new RegExp("((^|" + sufix +")[^\t]*)'", "g"), "$1\r")
+        .replace(new RegExp("((^|" + sufix +")[^\t]*)[^\\']'", "g"), "$1\r")
         .replace(new RegExp("\t=(.*?)" + sufix, "g"), "',$1,'")
         .split("\t").join("');")
         .split(sufix).join("p.push('")

--- a/test/index.html
+++ b/test/index.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <html>
   <head>
-    <title>EdenJS - Test</title>
+    <title>SpiceJS - Test</title>
     <script src="../index.js"></script>
     <script src="../bdd.js"></script>
   </head>
 
   <body>
     <p>Open console to view the results</p>
-    <script src="./lib/render_test.js"></script>
+    <script src="./lib/template_test.js"></script>
     <script src="./lib/observable_test.js"></script>
     <script src="./lib/route_test.js"></script>
     <script src="./lib/controller_test.js"></script>

--- a/test/lib/template_test.js
+++ b/test/lib/template_test.js
@@ -16,7 +16,7 @@ describe("#template", function() {
     assert.equal(S.template("<%= 10 %>", {}), "10");
     assert.equal(S.template("hi", {}), "hi");
     assert.equal(S.template('"hi"',  {}), '"hi"');
-    //assert.equal(S.template("'hi'",  {}), "'hi'");
+    assert.equal(S.template("'hi'",  {}), "'hi'");
   });
 
   it("compiles javascript code", function() {


### PR DESCRIPTION
We had an issue with single quotes not being escaped properly when using templates containing text with multiple single quotes.